### PR TITLE
add language_id to search index link

### DIFF
--- a/lib/model/SearchIndex.php
+++ b/lib/model/SearchIndex.php
@@ -4,10 +4,10 @@
  * @package    propel.generator.model
  */
 class SearchIndex extends BaseSearchIndex {
-	public function getLink() {
-		return LinkUtil::link($this->getLinkArray(), 'FrontendManager');
+	public function getLink($sLanguageId = null) {
+		return LinkUtil::link($this->getLinkArray(), 'FrontendManager', array(), $sLanguageId);
 	}
-	
+
 	public function getLinkArray() {
 		return $this->getPage()->getFullPathArray($this->getPathArray());
 	}
@@ -22,7 +22,7 @@ class SearchIndex extends BaseSearchIndex {
 		$oTemplate->replaceIdentifier("link_text", $this->getLinkText());
 		$oTemplate->replaceIdentifier("title", $this->getPageTitle());
 		$oTemplate->replaceIdentifier("description", $this->getPage()->getDescription());
-		$oTemplate->replaceIdentifier("url", $this->getLink());
+		$oTemplate->replaceIdentifier("url", $this->getLink($this->getLanguageId()));
 	}
 }
 


### PR DESCRIPTION
• search results were always showing the results of all languages, and linking to wrong language

I think this fixes an old problem of the FullTextSearchPlugin, used in multilingual sites.
Tested it locally on my multilingual site.