### PR TITLE
Single language search

### DIFF
--- a/modules/file/update_search_index/UpdateSearchIndexFileModule.php
+++ b/modules/file/update_search_index/UpdateSearchIndexFileModule.php
@@ -85,6 +85,9 @@ class UpdateSearchIndexFileModule extends FileModule {
 		}
 		FrontendManager::$CURRENT_PAGE = $oPageNavigationItem->getMe();
 		$oPage = FrontendManager::$CURRENT_PAGE;
+		if(!$oPage->hasPageStringByLanguage($this->sLanguageId)) {
+			return false;
+		}
 		$bIsNotFound = false;
 		FilterModule::getFilters()->handlePageHasBeenSet($oPage, $bIsNotFound, $oNavigationItem);
 		FilterModule::getFilters()->handleRequestStarted();

--- a/modules/page_type/search_result/SearchResultPageTypeModule.php
+++ b/modules/page_type/search_result/SearchResultPageTypeModule.php
@@ -35,7 +35,7 @@ class SearchResultPageTypeModule extends PageTypeModule {
 				}
 				$oSearchWordQuery->addOr(SearchIndexWordPeer::WORD, $sWord, $sComparison);
 			}
-			$oSearchWordQuery->joinSearchIndex()->useQuery('SearchIndex')->joinPage()->useQuery('Page')->active(true)->filterByIsProtected(false)->endUse()->endUse();
+			$oSearchWordQuery->joinSearchIndex()->useQuery('SearchIndex')->filterByLanguageId($sLanguageId)->joinPage()->useQuery('Page')->active(true)->filterByIsProtected(false)->endUse()->endUse();
 
 			foreach($oSearchWordQuery->find() as $oSearchIndexWord) {
 				$iId = $oSearchIndexWord->getSearchIndexId();


### PR DESCRIPTION
This fix makes sure that only pages of current language are indexed and displayed.

It would be nice to be able to search all languages, but the search result links - without this fix - still use the session language instead of the language of the search index.